### PR TITLE
Fix for Issue #593 (Bug in AjaxCart template)

### DIFF
--- a/snippets/ajax-cart-template.liquid
+++ b/snippets/ajax-cart-template.liquid
@@ -58,7 +58,6 @@
                     {{else}}
                       <span>{{{linePrice}}}</span>
                     {{/if}}
-                    </div>
                   </div>
                   {{#if discountsApplied}}
                     <div class="grid--full display-table">
@@ -69,7 +68,6 @@
                       </div>
                     </div>
                   {{/if}}
-                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Removed two stray </div> tags which were causing improper rendering of DOM on AjaxCart update. Previously, any additional products placed in the cart after the first product would be rendered outside their intended parent `.ajaxcart__inner`. products are now rendered correctly within `.ajaxcart__inner`.

Refer to Issue #593 for more information.